### PR TITLE
Fix `strnlen` compiler warning

### DIFF
--- a/source/memfault_http_task.c
+++ b/source/memfault_http_task.c
@@ -124,9 +124,9 @@ static void prv_auto_connect_to_ap(void) {
     if (connect_to_wifi_ap(ssid, auth_type, password, 2) != CY_RSLT_SUCCESS) {
       MEMFAULT_LOG_ERROR("Failed to connect to Wi-Fi AP w/ saved config");
     }
-  } else if (strnlen(WIFI_SSID, MEMFAULT_WIFI_CONFIG_MAX_SIZE) > 0 &&
-             strnlen(WIFI_AUTH_TYPE, MEMFAULT_WIFI_CONFIG_MAX_SIZE) > 0 &&
-             strnlen(WIFI_PASSWORD, MEMFAULT_WIFI_CONFIG_MAX_SIZE) > 0) {
+  } else if (strlen(WIFI_SSID) > 0 &&
+             strlen(WIFI_AUTH_TYPE) > 0 &&
+             strlen(WIFI_PASSWORD) > 0) {
     if (connect_to_wifi_ap(WIFI_SSID, WIFI_AUTH_TYPE, WIFI_PASSWORD, 2) != CY_RSLT_SUCCESS) {
       MEMFAULT_LOG_ERROR("Failed to connect to Wi-Fi AP w/ compile-time config");
     }


### PR DESCRIPTION
 ### Summary

Fix this warning when the build-time specified wifi credentials are set
to string literals less than 64 bytes:

```plaintext
source/memfault_http_task.c: In function 'prv_auto_connect_to_ap':
source/memfault_http_task.c:127:14: warning: 'strnlen' specified bound 64 exceeds source size 1 [-Wstringop-overread]
  127 |   } else if (strnlen(WIFI_SSID, MEMFAULT_WIFI_CONFIG_MAX_SIZE) > 0 &&
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Use `strlen` instead- it's evaluated at compile-time, since the string
is a `#define`'d literal value.

 ### Testing

Built with GCC ARM 12.2 with the following recipe, and confirmed the
warning is fixed:

```bash
~/ModusToolbox/tools_3.0/library-manager/library-manager-cli --project . --add-bsp-name ${BSP_NAME} --add-bsp-version latest-v4.X --add-bsp-location "local"
~/ModusToolbox/tools_3.0/library-manager/library-manager-cli --project . --set-active-bsp APP_CY8CKIT-062S2-43012
make build CY_COMPILER_GCC_ARM_DIR=~/.arm_toolchain/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin
```
