### PR TITLE
Release v1.3.0

### DIFF
--- a/deps/memfault-firmware-sdk.mtb
+++ b/deps/memfault-firmware-sdk.mtb
@@ -1,1 +1,1 @@
-https://github.com/memfault/memfault-firmware-sdk#0.37.0#$$ASSET_REPO$$/memfault-firmware-sdk/0.37.0
+https://github.com/memfault/memfault-firmware-sdk#0.43.1#$$ASSET_REPO$$/memfault-firmware-sdk/0.43.1

--- a/deps/mtb_kvstore.mtb
+++ b/deps/mtb_kvstore.mtb
@@ -1,1 +1,1 @@
-mtb://kv-store#release-v1.1.0#$$ASSET_REPO$$/kv-store/release-v1.1.0
+mtb://kv-store#latest-v1.X#$$ASSET_REPO$$/kv-store/latest-v1.X

--- a/source/main.c
+++ b/source/main.c
@@ -1,43 +1,43 @@
 /******************************************************************************
-* File Name:   main.c
-*
-* Description: This is the source code for TCP Secure Client Example in
-* ModusToolbox.
-*
-* Related Document: See Readme.md
-*
-*******************************************************************************
-* Copyright 2019-2021, Cypress Semiconductor Corporation (an Infineon company) or
-* an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
-*
-* This software, including source code, documentation and related
-* materials ("Software") is owned by Cypress Semiconductor Corporation
-* or one of its affiliates ("Cypress") and is protected by and subject to
-* worldwide patent protection (United States and foreign),
-* United States copyright laws and international treaty provisions.
-* Therefore, you may use this Software only as provided in the license
-* agreement accompanying the software package from which you
-* obtained this Software ("EULA").
-* If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
-* non-transferable license to copy, modify, and compile the Software
-* source code solely for use in connection with Cypress's
-* integrated circuit products.  Any reproduction, modification, translation,
-* compilation, or representation of this Software except as specified
-* above is prohibited without the express written permission of Cypress.
-*
-* Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
-* reserves the right to make changes to the Software without notice. Cypress
-* does not assume any liability arising out of the application or use of the
-* Software or any product or circuit described in the Software. Cypress does
-* not authorize its products for use in any products where a malfunction or
-* failure of the Cypress product may reasonably be expected to result in
-* significant property damage, injury or death ("High Risk Product"). By
-* including Cypress's product in a High Risk Product, the manufacturer
-* of such system or application assumes all risk of such use and in doing
-* so agrees to indemnify Cypress against all liability.
-*******************************************************************************/
+ * File Name:   main.c
+ *
+ * Description: This is the source code for TCP Secure Client Example in
+ * ModusToolbox.
+ *
+ * Related Document: See Readme.md
+ *
+ *******************************************************************************
+ * Copyright 2019-2021, Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation.  All rights reserved.
+ *
+ * This software, including source code, documentation and related
+ * materials ("Software") is owned by Cypress Semiconductor Corporation
+ * or one of its affiliates ("Cypress") and is protected by and subject to
+ * worldwide patent protection (United States and foreign),
+ * United States copyright laws and international treaty provisions.
+ * Therefore, you may use this Software only as provided in the license
+ * agreement accompanying the software package from which you
+ * obtained this Software ("EULA").
+ * If no EULA applies, Cypress hereby grants you a personal, non-exclusive,
+ * non-transferable license to copy, modify, and compile the Software
+ * source code solely for use in connection with Cypress's
+ * integrated circuit products.  Any reproduction, modification, translation,
+ * compilation, or representation of this Software except as specified
+ * above is prohibited without the express written permission of Cypress.
+ *
+ * Disclaimer: THIS SOFTWARE IS PROVIDED AS-IS, WITH NO WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, NONINFRINGEMENT, IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. Cypress
+ * reserves the right to make changes to the Software without notice. Cypress
+ * does not assume any liability arising out of the application or use of the
+ * Software or any product or circuit described in the Software. Cypress does
+ * not authorize its products for use in any products where a malfunction or
+ * failure of the Cypress product may reasonably be expected to result in
+ * significant property damage, injury or death ("High Risk Product"). By
+ * including Cypress's product in a High Risk Product, the manufacturer
+ * of such system or application assumes all risk of such use and in doing
+ * so agrees to indemnify Cypress against all liability.
+ *******************************************************************************/
 
 /* Header file includes */
 #include "cy_log.h"
@@ -53,54 +53,51 @@
 #include "memfault/components.h"
 #include "memfault_example_app.h"
 
-__attribute__((noreturn))
-int main(void)
-{
-    cy_rslt_t result;
+int main(void) {
+  cy_rslt_t result;
 
-    /* Initialize the board support package */
-    result = cybsp_init();
-    CY_ASSERT(result == CY_RSLT_SUCCESS);
+  /* Initialize the board support package */
+  result = cybsp_init();
+  CY_ASSERT(result == CY_RSLT_SUCCESS);
 
-    /* To avoid compiler warnings. */
-    (void) result;
+  /* To avoid compiler warnings. */
+  (void)result;
 
-    /* Enable global interrupts */
-    __enable_irq();
+  /* Enable global interrupts */
+  __enable_irq();
 
-    /* Initialize retarget-io to use the debug UART port */
-    cy_retarget_io_init(CYBSP_DEBUG_UART_TX, CYBSP_DEBUG_UART_RX,
-                        CY_RETARGET_IO_BAUDRATE);
+  /* Initialize retarget-io to use the debug UART port */
+  cy_retarget_io_init(CYBSP_DEBUG_UART_TX, CYBSP_DEBUG_UART_RX, CY_RETARGET_IO_BAUDRATE);
 
-    /* Initialize the User LED. */
-    cyhal_gpio_init(CYBSP_USER_LED, CYHAL_GPIO_DIR_OUTPUT,
-                        CYHAL_GPIO_DRIVE_STRONG, CYBSP_LED_STATE_OFF);
+  /* Initialize the User LED. */
+  cyhal_gpio_init(CYBSP_USER_LED, CYHAL_GPIO_DIR_OUTPUT, CYHAL_GPIO_DRIVE_STRONG,
+                  CYBSP_LED_STATE_OFF);
 
-    #if defined(TARGET_CY8CPROTO_062S3_4343W)
-    const uint32_t bus_frequency = 50000000lu;
+#if defined(TARGET_CY8CPROTO_062S3_4343W)
+  const uint32_t bus_frequency = 50000000lu;
 
-    cy_serial_flash_qspi_init(smifMemConfigs[0], CYBSP_QSPI_D0, CYBSP_QSPI_D1,
-                                  CYBSP_QSPI_D2, CYBSP_QSPI_D3, NC, NC, NC, NC,
-                                  CYBSP_QSPI_SCK, CYBSP_QSPI_SS, bus_frequency);
+  cy_serial_flash_qspi_init(smifMemConfigs[0], CYBSP_QSPI_D0, CYBSP_QSPI_D1, CYBSP_QSPI_D2,
+                            CYBSP_QSPI_D3, NC, NC, NC, NC, CYBSP_QSPI_SCK, CYBSP_QSPI_SS,
+                            bus_frequency);
 
-    cy_serial_flash_qspi_enable_xip(true);
-    #endif
+  cy_serial_flash_qspi_enable_xip(true);
+#endif
 
-    /* Enable logging */
-    result = cy_log_init(CY_LOG_INFO, NULL, NULL);
-    app_kvstore_init();
+  /* Enable logging */
+  result = cy_log_init(CY_LOG_INFO, NULL, NULL);
+  app_kvstore_init();
 
-    /* Initialize Memfault */
-    memfault_platform_init_serial_number();
-    memfault_platform_boot();
-    memfault_cli_task_start();
-    memfault_http_task_start();
+  /* Initialize Memfault */
+  memfault_platform_init_serial_number();
+  memfault_platform_boot();
+  memfault_cli_task_start();
+  memfault_http_task_start();
 
-    /* Start the FreeRTOS scheduler */
-    vTaskStartScheduler();
+  /* Start the FreeRTOS scheduler */
+  vTaskStartScheduler();
 
-    /* Should never get here */
-    CY_ASSERT(0);
+  /* Should never get here */
+  CY_ASSERT(0);
 }
 
 /* [] END OF FILE */

--- a/source/memfault_example_app.h
+++ b/source/memfault_example_app.h
@@ -9,16 +9,12 @@
 #include "cyhal.h"
 
 // #define WIFI_SSID "FILLMEIN"
+// #define WIFI_PASSWORD "FILLMEIN"
 //! Please see "wifi_utils_str_to_authtype" for string examples
 // #define WIFI_AUTH_TYPE "FILLMEIN"
-// #define WIFI_PASSWORD "FILLMEIN"
 
 // Get a project key from: https://mflt.io/project-key
 // #define MEMFAULT_PROJECT_KEY "YOUR_PROJECT_KEY"
-
-#if defined(__has_include) && __has_include("memfault_example_app_config.h")
-#include "memfault_example_app_config.h"
-#endif
 
 //! Creates a task which will manage the Memfault CLI
 void memfault_cli_task_start(void);

--- a/source/memfault_http_task.c
+++ b/source/memfault_http_task.c
@@ -68,21 +68,18 @@
 #include "memfault_psoc6_port.h"
 
 #if !defined(MEMFAULT_POST_SEND_INTERVAL_MS)
-#define MEMFAULT_POST_SEND_INTERVAL_MS              (60 * 1000)
+  #define MEMFAULT_POST_SEND_INTERVAL_MS              (60 * 1000)
 #endif
 
 #if !defined(WIFI_SSID)
-  #warning "WIFI_SSID should be defined in source/memfault_example_app.h"
   #define WIFI_SSID ""
 #endif
 
 #if !defined(WIFI_AUTH_TYPE)
-  #warning "WIFI_AUTH_TYPE should be defined in source/memfault_example_app.h"
   #define WIFI_AUTH_TYPE ""
 #endif
 
 #if !defined(WIFI_PASSWORD)
-  #warning "WIFI_PASSWORD should be defined in source/memfault_example_app.h"
   #define WIFI_PASSWORD ""
 #endif
 

--- a/source/memfault_platform_port.c
+++ b/source/memfault_platform_port.c
@@ -14,8 +14,6 @@
 #include "memfault_example_app.h"
 
 #if !defined(MEMFAULT_PROJECT_KEY)
-  #warning \
-    "#define MEMFAULT_PROJECT_KEY must be specified in source/memfault_example_app.h. Navigate to https://mflt.io/project-key to generate one"
   #define MEMFAULT_PROJECT_KEY ""
 #endif
 


### PR DESCRIPTION
- Remove default value warnings for WIFI_SSID, WIFI_AUTH_TYPE, WIFI_PASSWORD, and MEMFAULT_PROJECT_KEY
- Remove unused memfault_example_app_config.h include
- Remove noreturn attribute on main as this causes a warning due to implicit return value
- Update to latest mtb_kvstore
- Update to memfault-firmware-sdk 0.43.1